### PR TITLE
Bug room status room api schema fix

### DIFF
--- a/src/models/Room.js
+++ b/src/models/Room.js
@@ -360,7 +360,7 @@ const roomConverter = {
             tasklist: room.getTaskList().tasks,
             numImposters: room.getNumImposters(),
             numTasksToDo: room.getNumTasksToDo(),
-            players: room.getPlayerIds(),
+            playerIds: room.getPlayerIds(),
             };
     },
     fromFirestore: (snapshot, options) => {
@@ -370,7 +370,7 @@ const roomConverter = {
             tasks: data.tasklist
         }
         let room = new Room(data.id, data.adminId, data.code, data.createdAt, tasklistObj, data.numImposters, data.numTasksToDo);
-        room.setPlayerIds(data.players);
+        room.setPlayerIds(data.playerIds);
         console.log(`fromFirestore: data.status: ${data.status}`);
         room.setStatus(RoomStatus.enumValueOf(data.status));
         return room;

--- a/src/models/Room.js
+++ b/src/models/Room.js
@@ -38,7 +38,7 @@ export class Room {
     #tasklistObj;
     #numImposters;
     #numTasksToDo;
-    #players; // TODO: convert to Player
+    #playerIds; // TODO: convert to Player
     constructor(id, adminId, code, createdAt, tasklistObj, numImposters, numTasksToDo) { 
         this.status = RoomStatus.new;
         this.#id = id;
@@ -48,7 +48,7 @@ export class Room {
         this.#tasklistObj = tasklistObj;
         this.#numImposters = numImposters;
         this.#numTasksToDo = numTasksToDo;
-        this.#players = [];
+        this.#playerIds = [];
     }
 
     getRoomId() { return this.#id; }
@@ -58,7 +58,7 @@ export class Room {
     getTaskList() { return this.#tasklistObj; }
     getNumImposters() { return this.#numImposters; }
     getNumTasksToDo() { return this.#numTasksToDo; }
-    getPlayers() { return this.#players; }
+    getPlayerIds() { return this.#playerIds; }
     getStatus() {return this.status; }
 
     setRoomId(id) { this.#id = id; }
@@ -68,10 +68,10 @@ export class Room {
     setTaskList(tasklistObj) { this.#tasklistObj = tasklistObj; }
     setNumImposters(numImposters) { this.#numImposters = numImposters; }
     setNumTasksToDo(numTasksToDo) { this.#numTasksToDo = numTasksToDo; }
-    setPlayers(players) { this.#players = players; }
+    setPlayerIds(players) { this.#playerIds = players; }
     setStatus(status) { this.status = status; }
 
-    addPlayer(player) { this.#players.push(player); }
+    addPlayer(playerId) { this.#playerIds.push(playerId); }
 
     /**
      * Create a room for game play. This method calls _generateRoomCode and ensures 
@@ -305,7 +305,7 @@ export class Room {
             let room = await Room.getRoom(roomCode);
             
             // only add the player to this rooms `players` list if it doesn't exist in it
-            if (room.getPlayers().includes(playerId)) {
+            if (room.getPlayerIds().includes(playerId)) {
                 console.log("Player " + playerId + " already in room " + roomCode);
                 return room;
             }
@@ -351,7 +351,7 @@ export class Room {
 const roomConverter = {
     toFirestore: (room) => {
         return {
-            staus: room.getStatus(),
+            staus: room.getStatus().enumKey,
             id: room.getRoomId(),
             adminId: room.getAdminId(),
             code: room.getRoomCode(),
@@ -360,7 +360,7 @@ const roomConverter = {
             tasklist: room.getTaskList().tasks,
             numImposters: room.getNumImposters(),
             numTasksToDo: room.getNumTasksToDo(),
-            players: room.getPlayers(),
+            players: room.getPlayerIds(),
             };
     },
     fromFirestore: (snapshot, options) => {
@@ -370,7 +370,7 @@ const roomConverter = {
             tasks: data.tasklist
         }
         let room = new Room(data.id, data.adminId, data.code, data.createdAt, tasklistObj, data.numImposters, data.numTasksToDo);
-        room.setPlayers(data.players);
+        room.setPlayerIds(data.players);
         console.log(`fromFirestore: data.status: ${data.status}`);
         room.setStatus(RoomStatus.enumValueOf(data.status));
         return room;


### PR DESCRIPTION
Fixes a bug introduced during the development of RoomStatus where a RoomStatus instance was attempting to be saved to the database.

NOTE: apiUpdate: `getPlayers() --> getPlayerIds()`

This addresses an error that Firestore throws.

Also, addresses two schema - Model disagreements. Namely:

- schema: playerIds <-- model: players
- shema: status <-- model: RoomStatus object