### PR TITLE
fix bug in roomConverter

### DIFF
--- a/src/models/Room.js
+++ b/src/models/Room.js
@@ -352,6 +352,7 @@ const roomConverter = {
             adminId: room.getAdminId(),
             code: room.getRoomCode(),
             createdAt: serverTimestamp(),
+            tasklist: room.getTaskList(),
             numImposters: room.getNumImposters(),
             numTasksToDo: room.getNumTasksToDo(),
             playerIds: room.getPlayerIds(),


### PR DESCRIPTION
fix a bug caused by the roomConverter where tasklist arrays were not being saved in firestore.